### PR TITLE
Update to Wyam 1.6.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -294,4 +294,4 @@ __pycache__/
 
 config.wyam.dll
 config.wyam.hash
-packages.xml
+config.wyam.packages.xml

--- a/build.cake
+++ b/build.cake
@@ -1,6 +1,6 @@
 #tool "nuget:https://api.nuget.org/v3/index.json?package=KuduSync.NET&version=1.3.1"
-#tool "nuget:https://api.nuget.org/v3/index.json?package=Wyam&version=1.2.0"
-#addin "nuget:https://api.nuget.org/v3/index.json?package=Cake.Wyam&version=1.2.0"
+#tool "nuget:https://api.nuget.org/v3/index.json?package=Wyam&version=1.6.0"
+#addin "nuget:https://api.nuget.org/v3/index.json?package=Cake.Wyam&version=1.6.0"
 #addin "nuget:https://api.nuget.org/v3/index.json?package=Cake.Git&version=0.16.1"
 #addin "nuget:https://api.nuget.org/v3/index.json?package=Cake.Kudu&version=0.5.0"
 


### PR DESCRIPTION
This PR updates the site to Wyam 1.6.0. A small change with a big impact. Along with a more stable MSBuild integration, the update adds much better presentation of generic types and resolves several issues related to generic types.

Happy Hacktoberfest :smile: